### PR TITLE
 Fix minor address bar issues and Firefox 89 Compatibility Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,26 @@ Switch between Light Mode and Dark Mode without editing CSS.
 ## Installation
 
 1. **Install the userChrome**
+
+   1. **Manual installation** 
+
    - Download this project with the green 'Clone or download' button above or [here](https://github.com/diedummydie/Safari-Theme-for-Firefox/archive/master.zip) (zip)
    - Open your Firefox profile folder:
      - ☰ Menu > Help > Troubleshooting Information > Profile Folder: [Show...]
    - Create a folder in your profile called `chrome` if it does not already exist
    - Copy `userChrome.css` and `lib` into that new `chrome` folder
+
+   2. **Using Installation Script**
+
+   - Download this project with the green 'Clone or download' button above or [here](https://github.com/diedummydie/Safari-Theme-for-Firefox/archive/master.zip) (zip)
+   - Open terminal in the directory of the repo, and run `bash install.sh`
+   - Follow the prompts
+
 2. **Enable userChrome**
    - Open `about:config` in the address bar
    - Set the preference `toolkit.legacyUserProfileCustomizations.stylesheets` to `true`
    - Restart Firefox
+
 3. **Add the color themes**
    - [Safari Adaptive Light](https://addons.mozilla.org/en-US/firefox/addon/safari-adapt-light/)
    - [Safari Adaptive Dark](https://addons.mozilla.org/en-US/firefox/addon/safari-adapt-dark/)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Switch between Light Mode and Dark Mode without editing CSS.
 
 ![screenshot](https://raw.githubusercontent.com/diedummydie/Safari-Theme-for-Firefox/master/etc/screenshot.jpg)
 
+Comparison of Safari vs. Safari-Theme-for-Firefox 
+(notice the screen space gain! :partying_face:)
+
+![screenshot](https://i.imgur.com/r6tvfxL.png)
+
 ## Installation
 
 1. **Install the userChrome**

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Switch between Light Mode and Dark Mode without editing CSS.
 3. **Add the color themes**
    - [Safari Adaptive Light](https://addons.mozilla.org/en-US/firefox/addon/safari-adapt-light/)
    - [Safari Adaptive Dark](https://addons.mozilla.org/en-US/firefox/addon/safari-adapt-dark/)
+   - Add the extension to change Firefox's theme based on the time/system automatically [automaticDark](https://addons.mozilla.org/en-US/firefox/addon/automatic-dark/)
 
 - **Optional:**
   - Add the extension [Reload in address bar](https://addons.mozilla.org/en-US/firefox/addon/reload-in-address-bar/)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,58 @@
+MY_USERNAME="$(logname 2> /dev/null || echo ${SUDO_USER:-${USER}})"
+FIREFOX_DIR_HOME="/Users/${MY_USERNAME}/Library/Application Support/Firefox/Profiles"
+FIREFOX_DIR_PROFILE=$(echo "${FIREFOX_DIR_HOME}/"*"default-release")
+REPO_DIR="$(pwd)"
+
+ESC_SEQ="\x1b["
+COL_GREEN=$ESC_SEQ"32;01m"
+COL_RESET=$ESC_SEQ"39;49;00m"
+COL_RED=$ESC_SEQ"31;01m"
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+function warn() {
+  echo -e "$COL_ORANGE[warning]$COL_RESET $1"
+}
+function info() {
+  echo -e "$COL_YELLOW[action]:$COL_RESET ⇒ $1"
+}
+function success() {
+  echo -e "$COL_GREEN[success]$COL_RESET $1"
+}
+function kill_firefox() {
+  killall "firefox" &> /dev/null
+}
+function backup_firefox() {
+    { 
+        mv -f "${FIREFOX_DIR_PROFILE}/chrome" "${FIREFOX_DIR_PROFILE}/chrome"_$(date '+%Y%m%d-%H%M%S') && echo "Old profile: ${FIREFOX_DIR_PROFILE}/chrome" && echo "Backup profile: ${FIREFOX_DIR_PROFILE}/chrome"_$(date '+%Y%m%d-%H%M%S')
+    } || {
+        warn "Not able to find a chrome folder in the profile folder."
+    }
+}
+function install_ff_theme() {
+    ln -s "${REPO_DIR}" "${FIREFOX_DIR_PROFILE}/chrome"
+}
+
+echo -en "$COL_GREEN Firefox Safari theme. $COL_RESET"
+echo -en "\n"
+echo -en "\n"
+echo -e "${bold}Safari installer"
+echo -e "⚠ This is a script to add the theme into Firefox, and enable it."
+echo -e "⚠ Continuing will quit Firefox. Make sure you save any tabs before proceeding."
+
+echo -en "\n"
+warn "=> ${bold}$COL_RED CTRL+C $COL_RESET now to abort ${normal} or ${bold} $COL_GREEN ENTER ${normal} $COL_RESET to continue."
+
+tput bel
+read -n 1
+    info "Quit Firefox..."
+    kill_firefox
+    info "Backup your Firefox theme..."
+    backup_firefox
+    success "Done! The backup finished successfully."
+
+info "Installing Safari Firefox theme to your directory below"
+install_ff_theme
+success "Done! Safari Firefox theme has been installed."
+info "Restart Firefox and you're all set!"
+echo "Done."

--- a/userChrome.css
+++ b/userChrome.css
@@ -256,10 +256,6 @@ tab:-moz-window-inactive {
   display: -moz-box !important;
 }
 
-.tab-icon-image:-moz-window-inactive {
-  opacity: 0.1 !important;
-}
-
 .tab-label-container {
   margin-top: -1px;
   margin-left: -2px;
@@ -467,12 +463,6 @@ border-width: 3px !important;
 
 #context-navigation, #context-sep-navigation { 
   display: none !important 
-}
-
-
-/* Hide the favicon  */
-.tabbrowser-tab .tab-icon-image {
-  visibility: hidden !important;
 }
 
 /* Simplify the address bar:

--- a/userChrome.css
+++ b/userChrome.css
@@ -369,7 +369,7 @@ spacer {
   /* Compute new position, width, and padding */
 
   #urlbar[breakout][breakout-extend] {
-    top: 5px !important;
+    top: 3px !important;
     left: 0px !important;
     width: 100% !important;
     padding: 0px !important;
@@ -399,8 +399,9 @@ spacer {
 
   #urlbar[breakout][breakout-extend] > #urlbar-background {
     box-shadow: none !important;
+    border: none !important;
   }
-
+/*focused="true" breakout-extend="true"*/
 /*** END Firefox 77 (June 2, 2020) Override URL bar enlargement ***/
 
 
@@ -459,4 +460,30 @@ border-width: 3px !important;
 #urlbar-background
 {
 	border-color: var(--lwt-toolbar-field-background-color) !important;
+}
+
+#context-navigation, #context-sep-navigation { 
+  display: none !important 
+}
+
+
+.tabbrowser-tab .tab-icon-image {
+  visibility: hidden !important;
+}
+
+#urlbar-zoom-button,
+#identity-permission-box,
+#permissions-granted-icon,
+#star-button-box {
+  display:none!important
+}
+
+.tab-icon-overlay[soundplaying] {
+  top: 0;
+}
+
+#context-sendpagetodevice, #context-sep-sendpagetodevice,
+#context-sendlinktodevice, #context-sep-sendlinktodevice,
+#context_sendTabToDevice, #context_sendTabToDevice_separator {
+  display: none !important;
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -555,3 +555,7 @@ border-width: 3px !important;
 #pageAction-urlbar-_testpilot-containers {
   display: none !important;
 }
+.tab-icon-sound-label.tab-icon-sound-playing-label, 
+.tab-icon-sound-label.tab-icon-sound-pip-label {
+  display: none !important;
+}

--- a/userChrome.css
+++ b/userChrome.css
@@ -224,13 +224,13 @@ tab:-moz-window-inactive {
   border-bottom: none !important;
 }
 
-.tabbrowser-tab .tab-close-button {
+/*.tabbrowser-tab .tab-close-button {
   -moz-box-ordinal-group: 0 !important;
   margin: 1px 6px 1px -4px !important;
   width: 16px;
   height: 16px;
   display: none !important;
-}
+}*/
 
 .tab-icon-image {
   opacity: 0.9 !important;
@@ -496,5 +496,62 @@ border-width: 3px !important;
 #context-sendpagetodevice, #context-sep-sendpagetodevice,
 #context-sendlinktodevice, #context-sep-sendlinktodevice,
 #context_sendTabToDevice, #context_sendTabToDevice_separator {
+  display: none !important;
+}
+
+
+/* FF 89 */
+.tabbrowser-tab {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-right: 1px solid var(--tabs-border-color) !important;
+}
+.tab-background {
+  margin-top: 0px !important;
+  margin-bottom: 0px !important;
+  border-radius: 0 !important;
+}
+.tab-content {
+  margin-top: -2px !important;
+  padding-left: 25px !important;
+  padding-right: 0px !important;
+}
+#tabs-newtab-button {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  border-top: 1px solid var(--tabs-border-color) !important;
+}
+.tab-close-button {
+  margin-left: 0px !important;
+  visibility: hidden !important;
+  cursor: pointer !important;
+  padding: 2px !important;
+  width: 13px !important;
+  height: 13px !important;
+  border-radius: 3px !important;
+  margin-inline-end: initial !important;
+  margin-right: 10px !important;
+}
+.tabbrowser-tab:hover .tab-close-button {
+  visibility: initial !important;
+}
+.tab-label-container {
+  margin-top: -2px;
+  position: relative;
+  height:  20px !important;
+}
+.tabbrowser-tab:hover .tab-label-container {
+}
+.tab-label {
+  max-width: 100% !important;
+  position: absolute !important;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) !important;
+}
+.tab-icon-stack {
+  display: none !important;
+}
+#pageAction-urlbar-_testpilot-containers {
   display: none !important;
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -81,7 +81,7 @@ tab:-moz-window-inactive {
 
 #urlbar {
   background-image: linear-gradient(#ffffff06, #00000000) !important;
-  box-shadow: inset 0 0px 0 ffffff2a !important;
+  box-shadow: inset 0 0px 0 #ffffff2a !important;
   min-height: 22px !important;
   height: 24px !important;
   margin-top: 3px !important;
@@ -570,4 +570,11 @@ border-width: 3px !important;
 /* Hide Rainbow bar */
 #appMenu-fxa-separator {
   border-image: unset !important;
+}
+/* Dropdown URL */
+.urlbarView {
+  border: 1px solid var(--tabs-border-color) !important;
+  border-radius: var(--toolbarbutton-border-radius);
+  margin-top: 5px !important;
+  box-shadow: inset 0 0px 0 #ffffff2a !important;
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -467,10 +467,16 @@ border-width: 3px !important;
 }
 
 
+/* Hide the favicon  */
 .tabbrowser-tab .tab-icon-image {
   visibility: hidden !important;
 }
 
+/* Simplify the address bar:
+- Remove zoom
+- Remove permission granted icon
+- Remove bookmark icon
+*/
 #urlbar-zoom-button,
 #identity-permission-box,
 #permissions-granted-icon,
@@ -478,10 +484,12 @@ border-width: 3px !important;
   display:none!important
 }
 
+/* Fix the position of the sound icon when the tab plays media */
 .tab-icon-overlay[soundplaying] {
   top: 0;
 }
 
+/* Hide send page to device from the context menu */
 #context-sendpagetodevice, #context-sep-sendpagetodevice,
 #context-sendlinktodevice, #context-sep-sendlinktodevice,
 #context_sendTabToDevice, #context_sendTabToDevice_separator {

--- a/userChrome.css
+++ b/userChrome.css
@@ -485,8 +485,11 @@ border-width: 3px !important;
 }
 
 /* Fix the position of the sound icon when the tab plays media */
-.tab-icon-overlay[soundplaying] {
-  top: 0;
+.tab-icon-stack[soundplaying="true"] .tab-icon-overlay[soundplaying="true"] {
+  top: 0 !important;
+}
+.tab-icon-sound {
+  margin-top: -1px !important;
 }
 
 /* Hide send page to device from the context menu */

--- a/userChrome.css
+++ b/userChrome.css
@@ -224,14 +224,6 @@ tab:-moz-window-inactive {
   border-bottom: none !important;
 }
 
-/*.tabbrowser-tab .tab-close-button {
-  -moz-box-ordinal-group: 0 !important;
-  margin: 1px 6px 1px -4px !important;
-  width: 16px;
-  height: 16px;
-  display: none !important;
-}*/
-
 .tab-icon-image {
   opacity: 0.9 !important;
 }
@@ -518,6 +510,9 @@ border-width: 3px !important;
 .tabbrowser-tab[pinned] .tab-icon-stack {
   display: block !important;
 }
+.tabbrowser-tab[pinned] .tab-icon-stack .tab-icon-overlay {
+  display: none !important;
+}
 #tabs-newtab-button {
   padding-left: 0 !important;
   padding-right: 0 !important;
@@ -571,4 +566,8 @@ border-width: 3px !important;
 }
 #tabbrowser-tabs[haspinnedtabs]:not([positionpinnedtabs]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab[first-visible-unpinned-tab] {
   margin-inline-start: 0 !important;
+}
+/* Hide Rainbow bar */
+#appMenu-fxa-separator {
+  border-image: unset !important;
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -89,7 +89,7 @@ tab:-moz-window-inactive {
   box-sizing: border-box;
   border: 0px #3b3b3b44 solid !important;
   border-bottom: 0px #37373744 solid !important;
-  top:;
+  top: 4px !important;
 }
 
 #urlbar:-moz-window-inactive {
@@ -104,11 +104,11 @@ tab:-moz-window-inactive {
     hsla(0, 0%, 100%, 1)
   ) !important;
   box-shadow: inset 0 1px 0 #ffffff22 !important;
-  padding: 3.25px 11px !important;
+  padding: 3.25px 9px !important;
   margin-left: 2px !important;
   margin-right: 2px !important;
   height: 24px !important;
-  width: 39px !important;
+  width: 31px !important;
   border-radius: 5px !important;
   opacity: 1 !important;
   background-clip: padding-box;
@@ -443,8 +443,11 @@ border-width: 3px !important;
   display: block;
   position: absolute;
   width: 100%;
-  top: 3px !important;
   left: 0;
+}
+
+#urlbar[breakout][breakout-extend] {
+  top: 4px !important;
 }
 
 #urlbar {
@@ -525,10 +528,10 @@ border-width: 3px !important;
   margin-left: 0px !important;
   visibility: hidden !important;
   cursor: pointer !important;
-  padding: 2px !important;
-  width: 13px !important;
-  height: 13px !important;
-  border-radius: 3px !important;
+  padding: 3px !important;
+  width: 15px !important;
+  height: 15px !important;
+  border-radius: 2px !important;
   margin-inline-end: initial !important;
   margin-right: 10px !important;
 }
@@ -558,4 +561,18 @@ border-width: 3px !important;
 .tab-icon-sound-label.tab-icon-sound-playing-label, 
 .tab-icon-sound-label.tab-icon-sound-pip-label {
   display: none !important;
+}
+.urlbar-input-box {
+  font-size: 12px !important;
+}
+#identity-box {
+  margin-right: 0 !important;
+}
+#identity-icon {
+  width: 11px !important;
+  height: 11px !important;
+}
+#tabs-newtab-button {
+  cursor: pointer !important;
+}
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -519,6 +519,15 @@ border-width: 3px !important;
   padding-left: 25px !important;
   padding-right: 0px !important;
 }
+.tab-icon-stack {
+  display: none !important;
+}
+.tabbrowser-tab[pinned] .tab-content {
+  padding-left: 5px !important;
+}
+.tabbrowser-tab[pinned] .tab-icon-stack {
+  display: block !important;
+}
 #tabs-newtab-button {
   padding-left: 0 !important;
   padding-right: 0 !important;
@@ -543,17 +552,12 @@ border-width: 3px !important;
   position: relative;
   height:  20px !important;
 }
-.tabbrowser-tab:hover .tab-label-container {
-}
 .tab-label {
   max-width: 100% !important;
   position: absolute !important;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) !important;
-}
-.tab-icon-stack {
-  display: none !important;
 }
 #pageAction-urlbar-_testpilot-containers {
   display: none !important;
@@ -575,4 +579,6 @@ border-width: 3px !important;
 #tabs-newtab-button {
   cursor: pointer !important;
 }
+#tabbrowser-tabs[haspinnedtabs]:not([positionpinnedtabs]) > #tabbrowser-arrowscrollbox > .tabbrowser-tab[first-visible-unpinned-tab] {
+  margin-inline-start: 0 !important;
 }


### PR DESCRIPTION
- Fix the inconsistent position of the address bar in focus. 
- Simplify the address bar, not only making the theme matching to the old-school Safari more but also adding more space to [Chrome-clone translation add-on](https://addons.mozilla.org/en-US/firefox/addon/traduzir-paginas-web/).
- An installation script has been added to streamline the installation process.
- Update README.md.
- Update Firefox 89.


https://user-images.githubusercontent.com/3027146/119815632-0c214b80-beec-11eb-9036-131c36d01ddd.mp4

<img width="1904" alt="Screen Shot 2021-05-27 at 1 00 28 PM" src="https://user-images.githubusercontent.com/3027146/119815834-45f25200-beec-11eb-858d-2ddbeafcf8f1.png">

