### PR TITLE
Fix close tab and favicon

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -527,6 +527,13 @@ border-width: 3px !important;
 #identity-box {
   margin-right: 0 !important;
 }
+#identity-box[pageproxystate="valid"].extensionPage > .identity-box-button {
+  background-color: transparent !important;
+  padding-inline: 5px !important;
+}
+#identity-box[pageproxystate="valid"].extensionPage #identity-icon-label {
+  display: none !important;
+}
 #identity-icon {
   width: 11px !important;
   height: 11px !important;
@@ -576,6 +583,18 @@ border-width: 3px !important;
 }
 .tab-close-button,
 .tab-icon-overlay,
-.tab-icon-sound-label.tab-icon-sound-tooltip-label {
+.tab-icon-sound-label.tab-icon-sound-tooltip-label,
+#pageAction-urlbar-_0d49b33c-467a-4897-bea4-c82d6756e5c4_ {
   display: none;
+}
+#tabs-newtab-button {
+  width: 25px !important;
+}
+#tabs-newtab-button .toolbarbutton-icon {
+  width: 17px !important;
+  height: 17px !important;
+  opacity: 0.4 !important;
+}
+.tab-icon-image {
+  visibility: hidden !important;
 }

--- a/userChrome.css
+++ b/userChrome.css
@@ -491,6 +491,11 @@ border-width: 3px !important;
 }
 .tabbrowser-tab[pinned] .tab-content {
   padding-left: 5px !important;
+  padding-right: 5px !important;
+}
+.tabbrowser-tab[pinned] .tab-content .tab-icon-image {
+  margin-left: 2px !important;
+  margin-right: 2px !important;
 }
 #tabs-newtab-button {
   padding-left: 0 !important;

--- a/userChrome.css
+++ b/userChrome.css
@@ -239,15 +239,6 @@ tab:-moz-window-inactive {
   transition-duration: 0.1s !important;
 }
 
-.tabbrowser-tab:not([pinned="true"]):hover .tab-icon-image,
-.tabbrowser-tab:not([pinned="true"]):hover .tab-throbber {
-  display: none;
-}
-
-.tabbrowser-tab:not([pinned="true"]):hover .tab-close-button {
-  display: -moz-box !important;
-}
-
 .tab-label-container {
   margin-top: -1px;
   margin-left: -2px;
@@ -473,9 +464,6 @@ border-width: 3px !important;
 .tab-icon-stack[soundplaying="true"] .tab-icon-overlay[soundplaying="true"] {
   top: 0 !important;
 }
-.tab-icon-sound {
-  margin-top: -1px !important;
-}
 
 /* Hide send page to device from the context menu */
 #context-sendpagetodevice, #context-sep-sendpagetodevice,
@@ -498,39 +486,16 @@ border-width: 3px !important;
 }
 .tab-content {
   margin-top: -2px !important;
-  padding-left: 25px !important;
-  padding-right: 0px !important;
-}
-.tab-icon-stack {
-  display: none !important;
+  padding-left: 10px !important;
+  padding-right: 10px !important;
 }
 .tabbrowser-tab[pinned] .tab-content {
   padding-left: 5px !important;
-}
-.tabbrowser-tab[pinned] .tab-icon-stack {
-  display: block !important;
-}
-.tabbrowser-tab[pinned] .tab-icon-stack .tab-icon-overlay {
-  display: none !important;
 }
 #tabs-newtab-button {
   padding-left: 0 !important;
   padding-right: 0 !important;
   border-top: 1px solid var(--tabs-border-color) !important;
-}
-.tab-close-button {
-  margin-left: 0px !important;
-  visibility: hidden !important;
-  cursor: pointer !important;
-  padding: 3px !important;
-  width: 15px !important;
-  height: 15px !important;
-  border-radius: 2px !important;
-  margin-inline-end: initial !important;
-  margin-right: 10px !important;
-}
-.tabbrowser-tab:hover .tab-close-button {
-  visibility: initial !important;
 }
 .tab-label-container {
   margin-top: -2px;
@@ -577,4 +542,35 @@ border-width: 3px !important;
   border-radius: var(--toolbarbutton-border-radius);
   margin-top: 5px !important;
   box-shadow: inset 0 0px 0 #ffffff2a !important;
+}
+
+.tabbrowser-tab .tab-throbber,
+.tabbrowser-tab .tab-icon-image,
+.tabbrowser-tab .tab-sharing-icon-overlay,
+.tabbrowser-tab .tab-icon-overlay,
+.tabbrowser-tab .tab-label-container,
+.tabbrowser-tab .tab-icon-sound {
+  -moz-box-ordinal-group: 2 !important;
+}
+.tabbrowser-tab .tab-close-button {
+  margin-right: 7px !important;
+}
+.tab-close-button {
+  cursor: pointer !important;
+  padding: 3px !important;
+  width: 15px !important;
+  height: 15px !important;
+  border-radius: 2px !important;
+}
+.tabbrowser-tab:not([pinned="true"]):hover .tab-close-button {
+  display: -moz-box !important;
+}
+.tabbrowser-tab:not([pinned="true"]):hover .tab-icon-image,
+.tabbrowser-tab:not([pinned="true"]):hover .tab-throbber {
+  display: none;
+}
+.tab-close-button,
+.tab-icon-overlay,
+.tab-icon-sound-label.tab-icon-sound-tooltip-label {
+  display: none;
 }


### PR DESCRIPTION
- Thanks to @biosmanager - https://gist.github.com/biosmanager/93544485fb0da3ad0577856186b9b3e8, now the Close Tab is on the left.
- Bring back the favicon to the tab.
<img width="1790" alt="Screen Shot 2021-06-06 at 10 20 23 AM" src="https://user-images.githubusercontent.com/3027146/120917681-cebd7a80-c6b0-11eb-87cf-58d65584a00e.png">
<img width="1791" alt="Screen Shot 2021-06-06 at 10 20 33 AM" src="https://user-images.githubusercontent.com/3027146/120917684-d54bf200-c6b0-11eb-9ecb-e3bb41b68e61.png">
